### PR TITLE
Update _dock_widget.py imports

### DIFF
--- a/src/vessel_express/_dock_widget.py
+++ b/src/vessel_express/_dock_widget.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QComboBox, QLabel, QSizePolicy, QToolBox, QLineEdit
+from qtpy.QtWidgets import QComboBox, QLabel, QSizePolicy, QToolBox, QLineEdit
 from inspect import CORO_CLOSED
 import napari
 from napari_plugin_engine import napari_hook_implementation


### PR DESCRIPTION
Using pyqt5 directly will lead to issues with the napari bundle application that relies on pyside2.

Please import from `qtpy` only.

Thanks!

See https://github.com/conda-forge/staged-recipes/pull/19257/files